### PR TITLE
Fix typo in registry_size.py

### DIFF
--- a/Python/registry_size.py
+++ b/Python/registry_size.py
@@ -9,7 +9,7 @@ import sys
 import win32com
 from win32com.client import GetObject	
 
-minRegSizeMB = 55
+minRegistrySizeMB = 55
 
 if len(sys.argv) > 1:
 	minRegistrySizeMB	= int(sys.argv[1])


### PR DESCRIPTION
Fix small typo that was causing an error in the registry size check.