### PR TITLE
Fix Typo in Python -> parent_process.py

### DIFF
--- a/Python/parent_process.py
+++ b/Python/parent_process.py
@@ -15,7 +15,7 @@ expectedParentProc = "firefox"
 if len(sys.argv) == 2:
   expectedParentProc = sys.argv[1]
 
-processes = GetObject("winmgmts:").ExecQuery('SELECT CommandLine from Win32_Process WHERE ProcessID = ' + str(os.getpid())) 
+processes = GetObject("winmgmts:").ExecQuery('SELECT CommandLine from Win32_Process WHERE ProcessID = ' + str(os.getpid()))
 
 for process in processes:
   if expectedParentProc in str(process.Properties_('CommandLine')):

--- a/Python/parent_process.py
+++ b/Python/parent_process.py
@@ -15,7 +15,7 @@ expectedParentProc = "firefox"
 if len(sys.argv) == 2:
   expectedParentProc = sys.argv[1]
 
-processes = GetObject("winmgmts:").ExecQuery('SELECT CommandLine from Win32_Process WHERE ProcessID = ' + str(os.getppid()))  
+processes = GetObject("winmgmts:").ExecQuery('SELECT CommandLine from Win32_Process WHERE ProcessID = ' + str(os.getpid()))  
 
 for process in processes:
   if expectedParentProc in str(process.Properties_('CommandLine')):

--- a/Python/parent_process.py
+++ b/Python/parent_process.py
@@ -15,7 +15,7 @@ expectedParentProc = "firefox"
 if len(sys.argv) == 2:
   expectedParentProc = sys.argv[1]
 
-processes = GetObject("winmgmts:").ExecQuery('SELECT CommandLine from Win32_Process WHERE ProcessID = ' + str(os.getpid()))  
+processes = GetObject("winmgmts:").ExecQuery('SELECT CommandLine from Win32_Process WHERE ProcessID = ' + str(os.getpid())) 
 
 for process in processes:
   if expectedParentProc in str(process.Properties_('CommandLine')):


### PR DESCRIPTION
Original: os.getppid()
Fixed: os.getpid()